### PR TITLE
Support --update-only flag.

### DIFF
--- a/man/update-torbrowser.1.ronn
+++ b/man/update-torbrowser.1.ronn
@@ -39,6 +39,10 @@ how you want to proceed.
     `update-torbrowser` or by using the timeout utility as in the example
     below.
 
+  * `--update-only`
+
+    Do not download the Tor Browser when it is already up-to-date.
+
   * `--noask`
 
     Installs whatever the remote version file is claiming to be the lowest

--- a/man/update-torbrowser.1.ronn
+++ b/man/update-torbrowser.1.ronn
@@ -39,7 +39,7 @@ how you want to proceed.
     `update-torbrowser` or by using the timeout utility as in the example
     below.
 
-  * `--update-only`
+  * `--only-if-newer`
 
     Do not download the Tor Browser when it is already up-to-date.
 

--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -260,6 +260,10 @@ tb_parse_cmd_options() {
                TB_FORCE_INSTALL="1"
                shift
                ;;
+           --update-only)
+               UPDATE_ONLY="1"
+               shift
+               ;;
            --nokilltb)
                NOKILLTB="1"
                shift
@@ -1238,6 +1242,12 @@ To update $tb_title inside existing TemplateBasedVMs, please update $tb_title in
          if [ "$dpkg_compare_versions_equals_exit_code" = "0" ]; then
             up_to_date_or_not_text="Looks like $tb_title is already up to date."
             re_install_or_install_text="Please close $tb_title if you want to (re-)install!"
+	    if [ "$UPDATE_ONLY" = "1" ]; then
+		echo "INFO: UPDATE_ONLY is set 1."
+		echo "Skip downloading: current $tb_title $tbb_locally_installed_version is already up-to-date."
+
+	        tb_exit_function 0
+	    fi
          elif [ "$dpkg_compare_versions_greater_than_exit_code" = "0" ]; then
             up_to_date_or_not_text="Looks like there is an upgrade for $tb_title."
             re_install_or_install_text="Please close $tb_title if you want to (re-)install!"

--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -260,8 +260,8 @@ tb_parse_cmd_options() {
                TB_FORCE_INSTALL="1"
                shift
                ;;
-           --update-only)
-               UPDATE_ONLY="1"
+           --only-if-newer)
+               UPDATE_ONLY_IF_NEWER="1"
                shift
                ;;
            --nokilltb)
@@ -1242,8 +1242,8 @@ To update $tb_title inside existing TemplateBasedVMs, please update $tb_title in
          if [ "$dpkg_compare_versions_equals_exit_code" = "0" ]; then
             up_to_date_or_not_text="Looks like $tb_title is already up to date."
             re_install_or_install_text="Please close $tb_title if you want to (re-)install!"
-	    if [ "$UPDATE_ONLY" = "1" ]; then
-		echo "INFO: UPDATE_ONLY is set 1."
+	    if [ "$UPDATE_ONLY_IF_NEWER" = "1" ]; then
+		echo "INFO: UPDATE_ONLY_IF_NEWER is set 1."
 		echo "Skip downloading: current $tb_title $tbb_locally_installed_version is already up-to-date."
 
 	        tb_exit_function 0


### PR DESCRIPTION
When the Tor Browser is already up-to-date, the current tb-updater will still ask users if they want to download and reinstall it.

With this `--update-only` flag turned on, the tb-updater will exit with a message like "Skip downloading: current Tor Browser 11.5 is already up-to-date".

This flag is especially useful when tb-updater is run regularly to keep the Tor Browser up-to-date because it saves user from spending time and resources downloading an already up-to-date Tor Browser.