### PR TITLE
Make update-torbrowser work with new multi-lang builds

### DIFF
--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -1356,7 +1356,10 @@ tb_version_processing() {
    fi
 
    ## Check if TB_LANG exists and is not empty.
-   if [[ "$TB_LANG" && "${TB_LANG}" ]]; then
+   if dpkg --compare-versions "$tbb_version" ge "12.0a4" ; then
+      echo "INFO: Requested Tor Browser version only support an ALL locale, fetching it."
+      TB_LANG="ALL"
+   elif [[ "$TB_LANG" && "${TB_LANG}" ]]; then
       #echo "INFO: Tor Browser language variable is set to "$TB_LANG"."
       echo "INFO: $tb_title language variable TB_LANG is already set to '$TB_LANG'. Keeping it as is, ok."
    else


### PR DESCRIPTION
As of v12.0a4 Tor Browser is shipped as a multi-language archive
and language-specific archives are no longer available. This
patch makes this new multi-lang version install properly but does
not handle starting Tor Browser with the correct locale.

I'm not entirely sure how the locale should be handled. Is it
good enough to just use the system language (which Tor Browser
now does by default) or should some other solution be used? If
the system language is good enough, I'd suggest just merging
this change as is and once v12 stable is released TB_LANG
support can be removed.