### PR TITLE
Change min $tbb_version for TB_LANG="ALL"

### DIFF
--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -1356,7 +1356,7 @@ tb_version_processing() {
    fi
 
    ## Check if TB_LANG exists and is not empty.
-   if dpkg --compare-versions "$tbb_version" ge "12.0a4" ; then
+   if dpkg --compare-versions "$tbb_version" ge "12.0" ; then
       echo "INFO: Requested Tor Browser version only support an ALL locale, fetching it."
       TB_LANG="ALL"
    elif [[ "$TB_LANG" && "${TB_LANG}" ]]; then


### PR DESCRIPTION
This resolves curl not finding packages ending with "en-US" since new packages use "ALL" instead (and versions < 12.0a4 no longer seem to be available): https://dist.torproject.org/torbrowser/12.0/