### PR TITLE
Download broken for Tor Browser 13.0a3

### DIFF
--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -683,7 +683,7 @@ tb_preparation() {
    if [ "$ARCH_DOWNLOAD" = "" ]; then
       echo "INFO: Auto detecting ARCH_DOWNLOAD..."
       if [ "$ARCH" = "x86_64" ]; then
-         [ -n "$ARCH_DOWNLOAD" ] || ARCH_DOWNLOAD="linux64"
+         [ -n "$ARCH_DOWNLOAD" ] || ARCH_DOWNLOAD="linux-x86_64"
       elif [ "$ARCH" = "i386" ]; then
          [ -n "$ARCH_DOWNLOAD" ] || ARCH_DOWNLOAD="linux32"
       elif [ "$ARCH" = "i686" ]; then
@@ -1374,7 +1374,7 @@ tb_version_processing() {
    [ -n "$tbb_version_folder" ] || tbb_version_folder="${tbb_version}"
    [ -n "$TBB_EXTRA_FOLDER" ] || TBB_EXTRA_FOLDER="${tbb_version_folder}"
 
-   [ -n "$TBB_SIG_FILENAME" ] || TBB_SIG_FILENAME="tor-browser-${ARCH_DOWNLOAD}-${tbb_version}_${TB_LANG}.tar.xz.asc"
+   [ -n "$TBB_SIG_FILENAME" ] || TBB_SIG_FILENAME="tor-browser-${ARCH_DOWNLOAD}-${tbb_version}.tar.xz.asc"
    [ -n "$TBB_SIG_LINK" ] || TBB_SIG_LINK="${TBB_REMOTE_FOLDER}/${TBB_EXTRA_FOLDER}/${TBB_SIG_FILENAME}${TBB_DOWNLOAD_APPENDIX}"
    [ -n "$TBB_SIG_FULL_PATH" ] || TBB_SIG_FULL_PATH="$tb_downloaded_files_folder/$TBB_SIG_FILENAME"
 


### PR DESCRIPTION
Looks like the Tor Project changed the naming schema for the *.tar.xz archives with 13.0a3. I adjusted the script to indicate what changed. This, of course, is not a complete patch as it ignoren other architectures, leaves some unused code around and break backward compatibility. Yet, I though I'd still open a pull request for discussing how this is best approached.

Options I can think of are:

* Ask TB if they could (temporarily) provide files using the old naming scheme (e.g. via symlink)
* Bind file name to version.

Download directory: http://scpalcwstkydpa3y7dbpkjs2dtr7zvtvdbyj3dqwkucfrwyixcl5ptqd.onion/torbrowser/13.0a3/