### PR TITLE
Clarify OpenPGP verification logic and stderr handling in Tor Browser updater

### DIFF
--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -1691,6 +1691,12 @@ tb_openpgp_verify() {
 
    ## stderr is merged into stdout with '2>&1' deliberately.
    ##
+   ## sqop implements the Stateless OpenPGP (SOP) specification.
+   ## Sequoia-PGP's own sop-rs trait library confirms this:
+   ##   "This crate defines an interface that is the Rust equivalent of
+   ##   [...] the Stateless OpenPGP Command Line Interface."
+   ## https://gitlab.com/sequoia-pgp/sop-rs/-/blob/main/src/lib.rs
+   ##
    ## The SOP specification guarantees no stderr on success:
    ##   "When sop succeeds, it will return 0 (OK) and emit nothing to
    ##   Standard Error."
@@ -1700,8 +1706,10 @@ tb_openpgp_verify() {
    ##
    ## The sqop (sequoia-sop) implementation enforces this: the verify
    ## helper routes diagnostic output to io::sink() (discarded) unless
-   ## '--verbose' is passed (which is not the case here).
+   ## '--verbose' is passed (which is not the case here). The CLI layer
+   ## (sop-rs) only writes to stderr via print_error_chain on error.
    ## https://gitlab.com/sequoia-pgp/sequoia-sop/-/blob/main/src/lib.rs
+   ## https://gitlab.com/sequoia-pgp/sop-rs/-/blob/main/src/cli.rs
    ##
    ## Therefore, on success (exit 0), sqop_output contains only stdout
    ## (the "TIMESTAMP FINGERPRINT ..." line), safe for parsing.

--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -1690,12 +1690,25 @@ tb_openpgp_verify() {
    log notice "sqop verify --not-before '$sqop_not_before' --not-after '$sqop_not_after' '$TBB_SIG_FULL_PATH' '$signing_key' < '$TBB_PACKAGE_FULL_PATH'"
 
    ## stderr is merged into stdout with '2>&1' deliberately.
-   ## 'sqop' (sequoia-sop) does not write to stderr on success (exit 0)
-   ## unless '--verbose' is used (which is not the case here). On failure
-   ## (exit non-zero), stderr may contain diagnostics, but those are
-   ## captured for the error message (sqop_output shown to user) and the
-   ## sig_creation_time parsing code is never reached because
-   ## verification_success remains false.
+   ##
+   ## The SOP specification guarantees no stderr on success:
+   ##   "When sop succeeds, it will return 0 (OK) and emit nothing to
+   ##   Standard Error."
+   ##   "When sop fails, it fails with a non-zero return code, and emits
+   ##   one or more warning messages on Standard Error."
+   ## https://gitlab.com/dkg/openpgp-stateless-cli/-/blob/main/sop.md
+   ##
+   ## The sqop (sequoia-sop) implementation enforces this: the verify
+   ## helper routes diagnostic output to io::sink() (discarded) unless
+   ## '--verbose' is passed (which is not the case here).
+   ## https://gitlab.com/sequoia-pgp/sequoia-sop/-/blob/main/src/lib.rs
+   ##
+   ## Therefore, on success (exit 0), sqop_output contains only stdout
+   ## (the "TIMESTAMP FINGERPRINT ..." line), safe for parsing.
+   ## On failure (exit non-zero), stderr diagnostics are captured for the
+   ## error message shown to the user, and the sig_creation_time parsing
+   ## code is never reached because verification_success remains false.
+   ##
    ## Separating stdout/stderr would add complexity without security benefit.
    if sqop_output="$(
       timeout --kill-after="60" "10" \

--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -1690,13 +1690,11 @@ tb_openpgp_verify() {
    log notice "sqop verify --not-before '$sqop_not_before' --not-after '$sqop_not_after' '$TBB_SIG_FULL_PATH' '$signing_key' < '$TBB_PACKAGE_FULL_PATH'"
 
    ## stderr is merged into stdout with '2>&1' deliberately.
-   ## Safe because the SOP spec guarantees no stderr on exit 0 (unless
-   ## --debug, which is not used here), and sqop's verify helper always
-   ## routes diagnostics to io::sink(). On failure (exit non-zero), stderr
-   ## is captured for the error message and sig_creation_time parsing is
-   ## never reached. Separating stdout/stderr would add complexity without
-   ## security benefit.
-   ## Details: https://www.kicksecure.com/wiki/OpenPGP#Sequoia-PGP_automation
+   ## Per the SOP spec, successful runs (exit 0) emit nothing to stderr
+   ## (--debug not used here). On failure (exit non-zero), stderr
+   ## diagnostics are captured for the error message and sig_creation_time
+   ## parsing is never reached.
+   ## https://www.kicksecure.com/wiki/OpenPGP#Sequoia-PGP_automation
    if sqop_output="$(
       timeout --kill-after="60" "10" \
          sqop verify \

--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -1689,6 +1689,14 @@ tb_openpgp_verify() {
 
    log notice "sqop verify --not-before '$sqop_not_before' --not-after '$sqop_not_after' '$TBB_SIG_FULL_PATH' '$signing_key' < '$TBB_PACKAGE_FULL_PATH'"
 
+   ## stderr is merged into stdout with '2>&1' deliberately.
+   ## 'sqop' (sequoia-sop) does not write to stderr on success (exit 0)
+   ## unless '--verbose' is used (which is not the case here). On failure
+   ## (exit non-zero), stderr may contain diagnostics, but those are
+   ## captured for the error message (sqop_output shown to user) and the
+   ## sig_creation_time parsing code is never reached because
+   ## verification_success remains false.
+   ## Separating stdout/stderr would add complexity without security benefit.
    if sqop_output="$(
       timeout --kill-after="60" "10" \
          sqop verify \
@@ -1703,12 +1711,20 @@ tb_openpgp_verify() {
       verification_success=false
    fi
 
-   ## 'sq verify' is used for informational output only (shown in the
+   ## 'sq verify' output is used for informational display (shown in the
    ## installation confirmation screen). It intentionally has no
    ## --not-before/--not-after time window because 'sqop verify' above
    ## already enforces signature freshness constraints. Signature creation
    ## timestamps are extracted from 'sqop' output only, since 'sq verify'
    ## does not expose them in a machine-parseable way.
+   ##
+   ## Verification decision logic:
+   ## - Only 'sqop verify' can set verification_success=true (above).
+   ## - Both 'sqop verify' and 'sq verify' can set verification_success=false.
+   ## - 'sq verify' failure therefore overrides a successful 'sqop verify'.
+   ## This is by design: both tools must agree for verification to pass,
+   ## providing defense in depth via two independent verification paths.
+   ##
    ## https://www.kicksecure.com/wiki/OpenPGP#Sequoia-PGP_automation
    ## https://forums.whonix.org/t/tor-browser-downloader-confirmation-has-changed-with-less-info/23146
    log notice "sq verify --signer-file '$signing_key' --signature-file '$TBB_SIG_FULL_PATH' '$TBB_PACKAGE_FULL_PATH'"
@@ -1721,7 +1737,7 @@ tb_openpgp_verify() {
          -- \
          "$TBB_PACKAGE_FULL_PATH" 2>&1
    )"; then
-      true "INFO: sq success. Not setting verification_success by design. That is up to sqop only."
+      true "INFO: sq success. Not setting verification_success=true by design. Only sqop can set true."
       #verification_success=false
    else
       verification_success=false

--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -1690,34 +1690,13 @@ tb_openpgp_verify() {
    log notice "sqop verify --not-before '$sqop_not_before' --not-after '$sqop_not_after' '$TBB_SIG_FULL_PATH' '$signing_key' < '$TBB_PACKAGE_FULL_PATH'"
 
    ## stderr is merged into stdout with '2>&1' deliberately.
-   ##
-   ## sqop implements the Stateless OpenPGP (SOP) specification.
-   ## Sequoia-PGP's own sop-rs trait library confirms this:
-   ##   "This crate defines an interface that is the Rust equivalent of
-   ##   [...] the Stateless OpenPGP Command Line Interface."
-   ## https://gitlab.com/sequoia-pgp/sop-rs/-/blob/main/src/lib.rs
-   ##
-   ## The SOP specification guarantees no stderr on success:
-   ##   "When sop succeeds, it will return 0 (OK) and emit nothing to
-   ##   Standard Error."
-   ##   "When sop fails, it fails with a non-zero return code, and emits
-   ##   one or more warning messages on Standard Error."
-   ## https://gitlab.com/dkg/openpgp-stateless-cli/-/blob/main/sop.md
-   ##
-   ## The sqop (sequoia-sop) implementation enforces this: the verify
-   ## helper routes diagnostic output to io::sink() (discarded) unless
-   ## '--verbose' is passed (which is not the case here). The CLI layer
-   ## (sop-rs) only writes to stderr via print_error_chain on error.
-   ## https://gitlab.com/sequoia-pgp/sequoia-sop/-/blob/main/src/lib.rs
-   ## https://gitlab.com/sequoia-pgp/sop-rs/-/blob/main/src/cli.rs
-   ##
-   ## Therefore, on success (exit 0), sqop_output contains only stdout
-   ## (the "TIMESTAMP FINGERPRINT ..." line), safe for parsing.
-   ## On failure (exit non-zero), stderr diagnostics are captured for the
-   ## error message shown to the user, and the sig_creation_time parsing
-   ## code is never reached because verification_success remains false.
-   ##
-   ## Separating stdout/stderr would add complexity without security benefit.
+   ## Safe because the SOP spec guarantees no stderr on exit 0 (unless
+   ## --debug, which is not used here), and sqop's verify helper always
+   ## routes diagnostics to io::sink(). On failure (exit non-zero), stderr
+   ## is captured for the error message and sig_creation_time parsing is
+   ## never reached. Separating stdout/stderr would add complexity without
+   ## security benefit.
+   ## Details: https://www.kicksecure.com/wiki/OpenPGP#Sequoia-PGP_automation
    if sqop_output="$(
       timeout --kill-after="60" "10" \
          sqop verify \
@@ -1732,12 +1711,13 @@ tb_openpgp_verify() {
       verification_success=false
    fi
 
-   ## 'sq verify' output is used for informational display (shown in the
-   ## installation confirmation screen). It intentionally has no
-   ## --not-before/--not-after time window because 'sqop verify' above
-   ## already enforces signature freshness constraints. Signature creation
-   ## timestamps are extracted from 'sqop' output only, since 'sq verify'
-   ## does not expose them in a machine-parseable way.
+   ## 'sq verify' output is for informational display only (shown in the
+   ## installation confirmation screen). Do not parse it — sq output is
+   ## not machine-readable.
+   ## Details: https://www.kicksecure.com/wiki/OpenPGP#sqop_vs_sq_for_automations
+   ##
+   ## No --not-before/--not-after: 'sqop verify' above already enforces
+   ## signature freshness. Timestamps extracted from 'sqop' output only.
    ##
    ## Verification decision logic:
    ## - Only 'sqop verify' can set verification_success=true (above).


### PR DESCRIPTION
## Summary
This PR improves code documentation and clarity in the Tor Browser updater's OpenPGP verification function without changing verification behavior. It adds detailed comments explaining the dual-verification approach and clarifies the rationale for merging stderr into stdout.

## Key Changes
- **Added comprehensive comment block** explaining why stderr is merged with stdout in the `sqop verify` command, including details about sqop's behavior on success/failure
- **Expanded verification logic documentation** to clarify the defense-in-depth approach:
  - Only `sqop verify` can set `verification_success=true`
  - Both tools can set it to `false`
  - `sq verify` failure overrides successful `sqop verify` by design
- **Improved existing comments** for clarity:
  - Changed "sq verify is used for informational output only" to "sq verify output is used for informational display"
  - Updated the info message from "Not setting verification_success by design" to "Not setting verification_success=true by design. Only sqop can set true." for better precision

## Implementation Details
The changes are purely documentation-focused, adding inline comments that explain:
- Why stderr redirection (`2>&1`) is necessary and safe
- How the two-tool verification strategy provides security benefits
- The specific conditions under which each verification tool affects the final result

No functional changes to the verification logic or behavior.

https://claude.ai/code/session_014Le7cr2Q3byZ2xk743yKVU